### PR TITLE
Fixes issues when running Goose on Windows.

### DIFF
--- a/src/metacoder/coders/base_coder.py
+++ b/src/metacoder/coders/base_coder.py
@@ -173,11 +173,15 @@ class BaseCoder(BaseModel, ABC):
         """
         if env is None:
             env = self.expand_env(self.env)
+
+        # Decode the child process output as UTF-8 (instead of default encoding)
         process = subprocess.Popen(
             command,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            encoding="utf-8",
+            errors="replace",  # avoid crashes on the occasional bad byte
             env=env,
             bufsize=1,
             universal_newlines=True,
@@ -189,7 +193,15 @@ class BaseCoder(BaseModel, ABC):
         # check verbosity level
         quiet_mode = logger.getEffectiveLevel() <= logging.INFO
 
-        def stream_output(pipe, output_lines, stream):
+        # Ensure our own stdout/stderr won't choke on non-ASCII (Windows consoles often do).
+        for s in (sys.stdout, sys.stderr):
+            try:
+                s.reconfigure(encoding="utf-8", errors="replace")  # Python 3.7+
+            except Exception as e:
+                logger.info(f"{e}")
+                pass  # OK if not available (e.g., redirected or older Python)
+
+        def stream_output(pipe, output_lines, stream):  # lines are already str decoded as UTF-8
             for line in iter(pipe.readline, ""):
                 if not quiet_mode:
                     print(line.rstrip(), file=stream)

--- a/src/metacoder/coders/base_coder.py
+++ b/src/metacoder/coders/base_coder.py
@@ -201,7 +201,8 @@ class BaseCoder(BaseModel, ABC):
                 logger.info(f"{e}")
                 pass  # OK if not available (e.g., redirected or older Python)
 
-        def stream_output(pipe, output_lines, stream):  # lines are already str decoded as UTF-8
+        # lines are already str decoded as UTF-8
+        def stream_output(pipe, output_lines, stream):
             for line in iter(pipe.readline, ""):
                 if not quiet_mode:
                     print(line.rstrip(), file=stream)

--- a/src/metacoder/coders/claude.py
+++ b/src/metacoder/coders/claude.py
@@ -246,7 +246,7 @@ class ClaudeCoder(BaseCoder):
                 ao.tool_uses = tool_uses
 
             end_time = time.time()
-            logger.info(f"🤖 Command took {end_time - start_time} seconds")
+            logger.info(f"🤖 Command took {end_time - start_time:.2f} seconds")
             ao.total_cost_usd = total_cost_usd
             ao.success = not is_error
             if not ao.success:

--- a/src/metacoder/coders/codex.py
+++ b/src/metacoder/coders/codex.py
@@ -115,7 +115,7 @@ class CodexCoder(BaseCoder):
             if "result" in message:
                 ao.result_text = message["result"]
         end_time = time.time()
-        print(f"🤖 Command took {end_time - start_time} seconds")
+        print(f"🤖 Command took {end_time - start_time:.2f} seconds")
         ao.total_cost_usd = total_cost_usd
         ao.success = not is_error
         if not ao.success:

--- a/src/metacoder/coders/gemini.py
+++ b/src/metacoder/coders/gemini.py
@@ -156,7 +156,7 @@ class GeminiCoder(BaseCoder):
                 )
 
             end_time = time.time()
-            logger.info(f"💎 Command took {end_time - start_time} seconds")
+            logger.info(f"💎 Command took {end_time - start_time:.2f} seconds")
 
             # Parse the output
             ao = CoderOutput(stdout=result.stdout, stderr=result.stderr)

--- a/src/metacoder/coders/goose.py
+++ b/src/metacoder/coders/goose.py
@@ -165,7 +165,7 @@ class GooseCoder(BaseCoder):
                     session_file = Path(session_file_str)
                     break
             if session_file and session_file.exists():
-                with open(session_file, "r") as f:
+                with open(session_file, "r", encoding="utf-8") as f:
                     ao.structured_messages = [
                         json.loads(line) for line in f if line.strip()
                     ]

--- a/src/metacoder/coders/goose.py
+++ b/src/metacoder/coders/goose.py
@@ -156,7 +156,7 @@ class GooseCoder(BaseCoder):
             result = self.run_process(command, env)
             end_time = time.time()
             ao = CoderOutput(stdout=result.stdout, stderr=result.stderr)
-            logger.info(f"🦆 Command took {end_time - start_time} seconds")
+            logger.info(f"🦆 Command took {end_time - start_time:.2f} seconds")
             # look in output text for a file like: logging to ./.local/share/goose/sessions/20250613_120403.jsonl
             session_file: Optional[Path] = None
             for line in result.stdout.split("\n"):

--- a/src/metacoder/coders/qwen.py
+++ b/src/metacoder/coders/qwen.py
@@ -90,7 +90,7 @@ class QwenCoder(BaseCoder):
                 )
 
             end_time = time.time()
-            print(f"🤖 Command took {end_time - start_time} seconds")
+            print(f"🤖 Command took {end_time - start_time:.2f} seconds")
 
             # Create output - Qwen CLI doesn't provide structured output
             ao = CoderOutput(

--- a/src/metacoder/evals/judges.py
+++ b/src/metacoder/evals/judges.py
@@ -23,7 +23,7 @@ class ClaudeJudge(DeepEvalBaseLLM):
         super().__init__()
         api_key = os.getenv("ANTHROPIC_API_KEY")
         if not api_key:
-            raise RuntimeError("ANTHROPIC_API_KEY is not set in environment.")
+            raise Exception("ANTHROPIC_API_KEY is not set in environment")
         self.client = Anthropic(api_key=api_key)
         self.model_name = model_name
         self.max_tokens = max_tokens

--- a/src/metacoder/evals/judges.py
+++ b/src/metacoder/evals/judges.py
@@ -1,0 +1,55 @@
+# metacoder/evals/judges.py
+
+import os
+
+from anthropic import Anthropic
+from anthropic.types import MessageParam, TextBlockParam, TextBlock
+from deepeval.models.base_model import DeepEvalBaseLLM
+
+class ClaudeJudge(DeepEvalBaseLLM):
+    """
+    Wraps Anthropic's Claude models so they can be used as
+    the `model` parameter to DeepEval metrics like GEval.
+    """
+
+    def __init__(
+        self,
+        model_name: str = "claude-3-5-sonnet-20240620",
+        max_tokens: int = 1024,
+        temperature: float = 0.0,
+    ):
+        super().__init__()
+        api_key = os.getenv("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise RuntimeError("ANTHROPIC_API_KEY is not set in environment.")
+        self.client = Anthropic(api_key = api_key)
+        self.model_name = model_name
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+
+    def load_model(self):
+        return self
+
+    def generate(self, prompt: str) -> str:
+        # Build typed content blocks and messages to satisfy the SDK's type hints
+        content: list[TextBlockParam] = [{"type": "text", "text": prompt}]
+        messages: list[MessageParam] = [{"role": "user", "content": content}]
+        resp = self.client.messages.create(
+            model = self.model_name,
+            max_tokens = self.max_tokens,
+            temperature = self.temperature,
+            messages = messages
+        )
+        # anthropic returns a list of content blocks; collect only the text blocks.
+        parts: list[str] = []
+        for block in resp.content:
+            if isinstance(block, TextBlock):
+                parts.append(block.text)
+        return "".join(parts)
+
+    async def a_generate(self, prompt: str) -> str:
+        # for now just call the sync path
+        return self.generate(prompt)
+
+    def get_model_name(self) -> str:
+        return self.model_name

--- a/src/metacoder/evals/judges.py
+++ b/src/metacoder/evals/judges.py
@@ -1,11 +1,13 @@
 # metacoder/evals/judges.py
-
+import logging
 import os
 
 from anthropic import Anthropic
 from anthropic.types import MessageParam, TextBlockParam, TextBlock
 
 from deepeval.models.base_model import DeepEvalBaseLLM
+
+logger = logging.getLogger(__name__)
 
 
 class ClaudeJudge(DeepEvalBaseLLM):
@@ -55,3 +57,29 @@ class ClaudeJudge(DeepEvalBaseLLM):
 
     def get_model_name(self) -> str:
         return self.model_name
+
+    def has_available_quota(self) -> bool:
+        """
+        Try a very lightweight request to check if quota is available.
+        Returns True if quota exists, False if Anthropic responds with
+        quota-related errors.
+        """
+        try:
+            # Use a minimal "ping" request
+            content: list[TextBlockParam] = [{"type": "text", "text": "ping"}]
+            messages: list[MessageParam] = [{"role": "user", "content": content}]
+            self.client.messages.create(
+                model=self.model_name,
+                max_tokens=1,  # cheapest possible
+                temperature=0.0,
+                messages=messages,
+            )
+            return True
+        except Exception as e:
+            msg = str(e).lower()
+            # Check for insufficient quota:
+            # 400 Bad Request. Message: Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.
+            if "credit balance is too low" in msg or "400" in msg:
+                logger.warning(f"ClaudeJudge quota check failed: {e}")
+                return False
+            raise

--- a/src/metacoder/evals/judges.py
+++ b/src/metacoder/evals/judges.py
@@ -16,9 +16,17 @@ class ClaudeJudge(DeepEvalBaseLLM):
     the `model` parameter to DeepEval metrics like GEval.
     """
 
+    # Note: Anthropic models can be listed via:
+    # curl https://api.anthropic.com/v1/models --header "x-api-key: %ANTHROPIC_API_KEY%" --header "anthropic-version: 2023-06-01"
+    # {"data": [{"type": "model", "id": "claude-opus-4-1-20250805", "display_name": "Claude Opus 4.1", "created_at": "2025-08-05T00:00:00Z"}, ... ]}
+    # Current list (September 3, 2025):
+    # claude-opus-4-1-20250805, claude-opus-4-20250514, claude-sonnet-4-20250514, claude-3-7-sonnet-20250219,
+    # claude-3-5-sonnet-20241022, claude-3-5-haiku-20241022, claude-3-5-sonnet-20240620, claude-3-haiku-20240307,
+    # claude-3-opus-20240229
+
     def __init__(
         self,
-        model_name: str = "claude-3-5-sonnet-20240620",
+        model_name: str = "claude-sonnet-4-20250514",
         max_tokens: int = 1024,
         temperature: float = 0.0,
     ):

--- a/src/metacoder/evals/judges.py
+++ b/src/metacoder/evals/judges.py
@@ -4,7 +4,9 @@ import os
 
 from anthropic import Anthropic
 from anthropic.types import MessageParam, TextBlockParam, TextBlock
+
 from deepeval.models.base_model import DeepEvalBaseLLM
+
 
 class ClaudeJudge(DeepEvalBaseLLM):
     """
@@ -22,7 +24,7 @@ class ClaudeJudge(DeepEvalBaseLLM):
         api_key = os.getenv("ANTHROPIC_API_KEY")
         if not api_key:
             raise RuntimeError("ANTHROPIC_API_KEY is not set in environment.")
-        self.client = Anthropic(api_key = api_key)
+        self.client = Anthropic(api_key=api_key)
         self.model_name = model_name
         self.max_tokens = max_tokens
         self.temperature = temperature
@@ -35,10 +37,10 @@ class ClaudeJudge(DeepEvalBaseLLM):
         content: list[TextBlockParam] = [{"type": "text", "text": prompt}]
         messages: list[MessageParam] = [{"role": "user", "content": content}]
         resp = self.client.messages.create(
-            model = self.model_name,
-            max_tokens = self.max_tokens,
-            temperature = self.temperature,
-            messages = messages
+            model=self.model_name,
+            max_tokens=self.max_tokens,
+            temperature=self.temperature,
+            messages=messages,
         )
         # anthropic returns a list of content blocks; collect only the text blocks.
         parts: list[str] = []

--- a/src/metacoder/evals/runner.py
+++ b/src/metacoder/evals/runner.py
@@ -518,21 +518,18 @@ class EvalRunner:
 
     def save_results(self, results: List[EvalResult], output_path: Path):
         """Save evaluation results to file."""
-        # output_path.parent.mkdir(parents=True, exist_ok=True)  # Not sure if the folder should be created here
-        data = {
-            "results": [r.model_dump() for r in results],
-            "summary": self.generate_summary(results),
-        }
+        # Convert to list of dicts
+        results_data = []
+        for result in results:
+            results_data.append(result.model_dump())
 
-        # Append a new YAML document to the output file.
-        with open(output_path, "a", encoding="utf-8", newline="") as f:
-            yaml.safe_dump(
-                data,
+        # Save as YAML
+        with open(output_path, "w") as f:
+            yaml.dump(
+                {"results": results_data, "summary": self.generate_summary(results)},
                 f,
-                explicit_start=True,  # writes '---' to mark a new document
                 default_flow_style=False,
                 sort_keys=False,
-                allow_unicode=True,
             )
 
     def generate_summary(self, results: List[EvalResult]) -> Dict[str, Any]:

--- a/src/metacoder/evals/runner.py
+++ b/src/metacoder/evals/runner.py
@@ -32,6 +32,7 @@ from metacoder.configuration import AIModelConfig, CoderConfig
 
 logger = logging.getLogger(__name__)
 
+
 class DummyMetric(BaseMetric):
     """A dummy metric that always returns a perfect score for testing."""
 
@@ -61,32 +62,37 @@ class DummyMetric(BaseMetric):
         """Check if the metric passed."""
         return self.success
 
+
 def make_geval(model: Optional[DeepEvalBaseLLM] = None) -> GEval:
     """Creates a GEval instance with the specified model."""
     return GEval(
         name="Correctness",
         criteria="Determine whether the actual output is factually correct based on the expected output.",
         # NOTE: you can only provide either criteria or evaluation_steps, and not both
-        evaluation_steps = [
+        evaluation_steps=[
             "Check whether the facts in 'actual output' contradicts any facts in 'expected output'",
             "You should also heavily penalize omission of detail",
             "Vague language, or contradicting OPINIONS, are OK",
         ],
-        threshold = 0.8,
-        evaluation_params = [
+        threshold=0.8,
+        evaluation_params=[
             LLMTestCaseParams.INPUT,
             LLMTestCaseParams.ACTUAL_OUTPUT,
             LLMTestCaseParams.EXPECTED_OUTPUT,
         ],
-        model = model # may be None (defaults to OpenAI) or a Claude judge
+        model=model,  # may be None (defaults to OpenAI) or a Claude judge
     )
 
 
-def get_default_metrics(model: Optional[DeepEvalBaseLLM] = None) -> Dict[str, BaseMetric]:
+def get_default_metrics(
+    model: Optional[DeepEvalBaseLLM] = None,
+) -> Dict[str, BaseMetric]:
     """Get default metrics with the specified model. Creates instances lazily to avoid network calls during import."""
     return {
-        "CorrectnessMetric": make_geval(model = model), # Note: GEval defaults to OpenAI if no model is specified.
-        "DummyMetric": DummyMetric(threshold = 0.5)
+        "CorrectnessMetric": make_geval(
+            model=model  # Note: GEval defaults to OpenAI if no model is specified.
+        ),
+        "DummyMetric": DummyMetric(threshold=0.5),
     }
 
 
@@ -131,7 +137,7 @@ class EvalRunner:
 
     def __init__(self, verbose: bool = False):
         self.verbose = verbose
-        self.use_openai = True # GEval will default to OpenAI, avoid it and downgrade to another provider or metric if quota runs out.
+        self.use_openai = True  # GEval will default to OpenAI, avoid it and downgrade to another provider or metric if quota runs out.
 
         if verbose:
             logging.basicConfig(level=logging.DEBUG)
@@ -205,16 +211,17 @@ class EvalRunner:
         """
         try:
             from openai import OpenAI
+
             # turn off SDK retries for the check so it returns fast
             client = OpenAI(max_retries=0, timeout=8)  # NO retries, quick fail
             # messages = cast(List[ChatCompletionMessageParam], [{"role": "user", "content": "ping"}])
             raw = [{"role": "user", "content": "ping"}]
             messages = cast(List[ChatCompletionMessageParam], raw)
             client.chat.completions.create(
-                model = model,
-                messages = messages,
-                max_tokens = 1,
-                temperature = 0,
+                model=model,
+                messages=messages,
+                max_tokens=1,
+                temperature=0,
             )
             return True
         except APIStatusError as e:
@@ -287,21 +294,33 @@ class EvalRunner:
                     self.use_openai = False
                     logger.warning("OpenAI quota exhausted; downgrading to Claude...")
                     from metacoder.evals.judges import ClaudeJudge
+
                     try:
                         # Downgrade to Claude judge in order to keep a real metric (even if not directly comparable to OpenAI).
-                        metric = make_geval(model = ClaudeJudge("claude-3-5-sonnet-20240620"))
+                        metric = make_geval(
+                            model=ClaudeJudge("claude-3-5-sonnet-20240620")
+                        )
                     except Exception as e:
                         # Fallback: if you can't use Claude, downgrade gracefully.
-                        logger.warning("Claude unavailable (%s); downgrading to DummyMetric.", e)
-                        metric = DummyMetric(threshold = 0.5)
+                        logger.warning(
+                            "Claude unavailable (%s); downgrading to DummyMetric.", e
+                        )
+                        metric = DummyMetric(threshold=0.5)
 
             eval_results = evaluate(
                 [test_case],
                 [metric],
-                async_config = AsyncConfig(run_async=False), # disable async
-                display_config = DisplayConfig(show_indicator=False, print_results=False, verbose_mode=self.verbose), # hide the spinner
-                cache_config = CacheConfig(use_cache=False, write_cache=False),
-                error_config = ErrorConfig(ignore_errors=False, skip_on_missing_params=True) # actually fail on failure
+                async_config=AsyncConfig(run_async=False),  # disable async
+                display_config=DisplayConfig(
+                    show_indicator=False,  # hide the progress meter
+                    print_results=False,
+                    verbose_mode=self.verbose,
+                ),
+                cache_config=CacheConfig(use_cache=False, write_cache=False),
+                error_config=ErrorConfig(
+                    ignore_errors=False,  # actually fail on failure
+                    skip_on_missing_params=True,
+                ),
             )
 
             # Extract results - the structure varies by deepeval version

--- a/src/metacoder/evals/runner.py
+++ b/src/metacoder/evals/runner.py
@@ -10,6 +10,7 @@ import importlib
 import logging
 import os
 import time
+import traceback
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Type, cast
 
@@ -225,15 +226,20 @@ class EvalRunner:
             )
             return True
         except APIStatusError as e:
-            # 429 insufficient_quota, or other status codes
+            # 429 insufficient quota or too many requests
             if e.status_code == 429:
-                logger.info(f"OpenAI API Key has insufficient quota: {e}")
+                logger.warning(f"OpenAI API Key has insufficient quota: {e}")
                 return False
-            logger.info(f"OpenAI API Status Error; treating as no-quota: {e}")
+            # 401 authentication problem, including invalid API key
+            if e.status_code == 401:
+                logger.warning(f"OpenAI API Authentication Error: {e}")
+                return False
+            # all other errors
+            logger.warning(f"OpenAI API Status Error; treating as no-quota: {e}")
             return False
         except Exception as e:
-            # includes 401 (bad key), 429 (insufficient_quota), network issues, etc.
-            logger.info(f"OpenAI preflight failed; treating as no-quota: {e}")
+            # includes network issues, etc.
+            logger.warning(f"OpenAI preflight failed; treating as no-quota: {e}")
             return False
 
     def run_single_eval(
@@ -288,27 +294,47 @@ class EvalRunner:
             test_case = self.create_test_case(case, actual_output)
 
             # Evaluate
-            logger.info(f"Evaluating with {metric_name}")
+            logger.info(
+                f"Evaluating {metric_name} using model {metric.model.model_name}"
+            )
 
             if isinstance(metric, GEval):
-                # Assume GEval will hit OpenAI unless we replace it.
+                # Assume GEval will use OpenAI until is disabled.
                 if self.use_openai and not self._openai_quota_ok():
-                    self.use_openai = False
-                    claude_model = "claude-3-5-sonnet-20240620"
                     logger.warning(
-                        f"OpenAI API quota exhausted or server unavailable; downgrading to {claude_model}"
+                        f"OpenAI API quota exhausted or server unavailable; disabling OpenAI for DeepEval."
                     )
+                    self.use_openai = False
+
+                # Note: This will downgrade a metric if needed each time it is about to be used without modifying the default metrics.
+                if not self.use_openai:
                     from metacoder.evals.judges import ClaudeJudge
 
+                    claude_model = "claude-3-5-sonnet-20240620"
+                    logger.warning(
+                        f"Downgrading {metric_name} model from {metric.model.model_name} to {claude_model}."
+                    )
+
                     try:
-                        # Downgrade to Claude judge in order to keep a real metric (even if not directly comparable to OpenAI).
+                        # Downgrade metric model to Claude judge.
                         metric = make_geval(model=ClaudeJudge(claude_model))
+                        logger.warning(
+                            f"Successfully downgraded {metric_name} model to {metric.model.model_name}."
+                        )
                     except Exception as e:
                         # Fallback: if you can't use Claude, downgrade gracefully.
+                        logging.error(traceback.format_exc())
                         logger.warning(
                             "Claude unavailable (%s); downgrading to DummyMetric.", e
                         )
                         metric = DummyMetric(threshold=0.5)
+                        logger.warning(
+                            f"Successfully downgraded {metric_name} model to {metric.model.model_name}."
+                        )
+
+            logger.warning(
+                f"Actual {metric_name} model used: {metric.model.model_name}"
+            )
 
             eval_results = evaluate(
                 [test_case],

--- a/src/metacoder/evals/runner.py
+++ b/src/metacoder/evals/runner.py
@@ -202,7 +202,7 @@ class EvalRunner:
     @functools.lru_cache(maxsize=1)
     def _openai_quota_ok(self, model: str = "gpt-4o-mini") -> bool:
         if not os.getenv("OPENAI_API_KEY"):
-            logger.warning("OPENAI_API_KEY is not set.")
+            logger.info("OPENAI_API_KEY is not set.")
             return False
         """
             Preflight: detect “no OpenAI quota” and skip/redirect before calling evaluate.
@@ -227,13 +227,13 @@ class EvalRunner:
         except APIStatusError as e:
             # 429 insufficient_quota, or other status codes
             if e.status_code == 429:
-                logger.warning(f"OpenAI API Key has insufficient quota: {e}")
+                logger.info(f"OpenAI API Key has insufficient quota: {e}")
                 return False
-            logger.warning(f"OpenAI API Status Error; treating as no-quota: {e}")
+            logger.info(f"OpenAI API Status Error; treating as no-quota: {e}")
             return False
         except Exception as e:
             # includes 401 (bad key), 429 (insufficient_quota), network issues, etc.
-            logger.warning(f"OpenAI preflight failed; treating as no-quota: {e}")
+            logger.info(f"OpenAI preflight failed; treating as no-quota: {e}")
             return False
 
     def run_single_eval(
@@ -294,13 +294,14 @@ class EvalRunner:
                 # Assume GEval will hit OpenAI unless we replace it.
                 if self.use_openai and not self._openai_quota_ok():
                     self.use_openai = False
-                    logger.warning("OpenAI quota exhausted; downgrading to Claude...")
+                    claude_model = "claude-3-5-sonnet-20240620"
+                    logger.warning(f"OpenAI API quota exhausted or server unavailable; downgrading to {claude_model}")
                     from metacoder.evals.judges import ClaudeJudge
 
                     try:
                         # Downgrade to Claude judge in order to keep a real metric (even if not directly comparable to OpenAI).
                         metric = make_geval(
-                            model=ClaudeJudge("claude-3-5-sonnet-20240620")
+                            model=ClaudeJudge(claude_model)
                         )
                     except Exception as e:
                         # Fallback: if you can't use Claude, downgrade gracefully.

--- a/src/metacoder/evals/runner.py
+++ b/src/metacoder/evals/runner.py
@@ -227,7 +227,9 @@ class EvalRunner:
         except APIStatusError as e:
             # 429 insufficient_quota, or other status codes
             if e.status_code == 429:
+                logger.warning(f"OpenAI API Key has insufficient quota: {e}")
                 return False
+            logger.warning(f"OpenAI API Status Error; treating as no-quota: {e}")
             return False
         except Exception as e:
             # includes 401 (bad key), 429 (insufficient_quota), network issues, etc.

--- a/src/metacoder/evals/runner.py
+++ b/src/metacoder/evals/runner.py
@@ -308,8 +308,6 @@ class EvalRunner:
 
                 # Note: This will downgrade a metric if needed each time it is about to be used without modifying the default metrics.
                 if not self.use_openai:
-                    from metacoder.evals.judges import ClaudeJudge
-
                     claude_model = "claude-3-5-sonnet-20240620"
                     logger.warning(
                         f"Downgrading {metric_name} model from {metric.model.model_name} to {claude_model}."
@@ -317,23 +315,28 @@ class EvalRunner:
 
                     try:
                         # Downgrade metric model to Claude judge.
-                        metric = make_geval(model=ClaudeJudge(claude_model))
-                        logger.warning(
+                        from metacoder.evals.judges import ClaudeJudge
+
+                        judge = ClaudeJudge(claude_model)
+
+                        if not judge.has_available_quota():
+                            raise Exception(
+                                "No Anthropic credits available for ClaudeJudge."
+                            )
+
+                        metric = make_geval(model=judge)
+                        logger.info(
                             f"Successfully downgraded {metric_name} model to {metric.model.model_name}."
                         )
                     except Exception as e:
                         # Fallback: if you can't use Claude, downgrade gracefully.
-                        logging.error(traceback.format_exc())
+                        logging.debug(traceback.format_exc())
+                        logger.debug(e)
                         logger.warning(
-                            "Claude unavailable (%s); downgrading {metric_name} to DummyMetric.",
-                            e,
+                            f"Claude unavailable ({e}); downgrading {metric_name} to DummyMetric."
                         )
                         metric = DummyMetric(threshold=0.5)
-                        logger.warning(
-                            f"Successfully downgraded {metric_name} to {metric.name}."
-                        )
-
-            logger.warning(f"Actual metric used: {metric.name}.")
+                        logger.warning(f"Downgraded {metric_name} to {metric.name}.")
 
             eval_results = evaluate(
                 [test_case],

--- a/src/metacoder/evals/runner.py
+++ b/src/metacoder/evals/runner.py
@@ -295,14 +295,14 @@ class EvalRunner:
                 if self.use_openai and not self._openai_quota_ok():
                     self.use_openai = False
                     claude_model = "claude-3-5-sonnet-20240620"
-                    logger.warning(f"OpenAI API quota exhausted or server unavailable; downgrading to {claude_model}")
+                    logger.warning(
+                        f"OpenAI API quota exhausted or server unavailable; downgrading to {claude_model}"
+                    )
                     from metacoder.evals.judges import ClaudeJudge
 
                     try:
                         # Downgrade to Claude judge in order to keep a real metric (even if not directly comparable to OpenAI).
-                        metric = make_geval(
-                            model=ClaudeJudge(claude_model)
-                        )
+                        metric = make_geval(model=ClaudeJudge(claude_model))
                     except Exception as e:
                         # Fallback: if you can't use Claude, downgrade gracefully.
                         logger.warning(

--- a/src/metacoder/evals/runner.py
+++ b/src/metacoder/evals/runner.py
@@ -302,7 +302,7 @@ class EvalRunner:
                 # Assume GEval will use OpenAI until is disabled.
                 if self.use_openai and not self._openai_quota_ok():
                     logger.warning(
-                        f"OpenAI API quota exhausted or server unavailable; disabling OpenAI for DeepEval."
+                        "OpenAI API quota exhausted or server unavailable; disabling OpenAI for DeepEval."
                     )
                     self.use_openai = False
 
@@ -325,16 +325,15 @@ class EvalRunner:
                         # Fallback: if you can't use Claude, downgrade gracefully.
                         logging.error(traceback.format_exc())
                         logger.warning(
-                            "Claude unavailable (%s); downgrading to DummyMetric.", e
+                            "Claude unavailable (%s); downgrading {metric_name} to DummyMetric.",
+                            e,
                         )
                         metric = DummyMetric(threshold=0.5)
                         logger.warning(
-                            f"Successfully downgraded {metric_name} model to {metric.model.model_name}."
+                            f"Successfully downgraded {metric_name} to {metric.name}."
                         )
 
-            logger.warning(
-                f"Actual {metric_name} model used: {metric.model.model_name}"
-            )
+            logger.warning(f"Actual metric used: {metric.name}.")
 
             eval_results = evaluate(
                 [test_case],

--- a/src/metacoder/evals/runner.py
+++ b/src/metacoder/evals/runner.py
@@ -518,18 +518,21 @@ class EvalRunner:
 
     def save_results(self, results: List[EvalResult], output_path: Path):
         """Save evaluation results to file."""
-        # Convert to list of dicts
-        results_data = []
-        for result in results:
-            results_data.append(result.model_dump())
+        # output_path.parent.mkdir(parents=True, exist_ok=True)  # Not sure if the folder should be created here
+        data = {
+            "results": [r.model_dump() for r in results],
+            "summary": self.generate_summary(results),
+        }
 
-        # Save as YAML
-        with open(output_path, "w") as f:
-            yaml.dump(
-                {"results": results_data, "summary": self.generate_summary(results)},
+        # Append a new YAML document to the output file.
+        with open(output_path, "a", encoding="utf-8", newline="") as f:
+            yaml.safe_dump(
+                data,
                 f,
+                explicit_start=True,  # writes '---' to mark a new document
                 default_flow_style=False,
                 sort_keys=False,
+                allow_unicode=True,
             )
 
     def generate_summary(self, results: List[EvalResult]) -> Dict[str, Any]:

--- a/src/metacoder/evals/runner.py
+++ b/src/metacoder/evals/runner.py
@@ -5,29 +5,32 @@ Runs evaluations across all combinations of model x coder x case x metric.
 """
 
 import copy
+import functools
 import importlib
 import logging
+import os
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Type, cast
 
 from pydantic import BaseModel
 import yaml
-from deepeval import evaluate
-from deepeval.metrics import BaseMetric
-from deepeval.test_case import LLMTestCase
-from deepeval.metrics import GEval
-from deepeval.test_case import LLMTestCaseParams
 
+from deepeval import evaluate
+from deepeval.evaluate import AsyncConfig, DisplayConfig, CacheConfig, ErrorConfig
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.metrics import BaseMetric, GEval
+from deepeval.test_case import LLMTestCase, LLMTestCaseParams
+
+from openai import APIStatusError
+from openai.types.chat import ChatCompletionMessageParam
 
 from metacoder.coders.base_coder import BaseCoder, CoderOutput
 from metacoder.registry import AVAILABLE_CODERS
 from metacoder.evals.eval_model import EvalCase, EvalDataset
 from metacoder.configuration import AIModelConfig, CoderConfig
 
-
 logger = logging.getLogger(__name__)
-
 
 class DummyMetric(BaseMetric):
     """A dummy metric that always returns a perfect score for testing."""
@@ -58,27 +61,32 @@ class DummyMetric(BaseMetric):
         """Check if the metric passed."""
         return self.success
 
+def make_geval(model: Optional[DeepEvalBaseLLM] = None) -> GEval:
+    """Creates a GEval instance with the specified model."""
+    return GEval(
+        name="Correctness",
+        criteria="Determine whether the actual output is factually correct based on the expected output.",
+        # NOTE: you can only provide either criteria or evaluation_steps, and not both
+        evaluation_steps = [
+            "Check whether the facts in 'actual output' contradicts any facts in 'expected output'",
+            "You should also heavily penalize omission of detail",
+            "Vague language, or contradicting OPINIONS, are OK",
+        ],
+        threshold = 0.8,
+        evaluation_params = [
+            LLMTestCaseParams.INPUT,
+            LLMTestCaseParams.ACTUAL_OUTPUT,
+            LLMTestCaseParams.EXPECTED_OUTPUT,
+        ],
+        model = model # may be None (defaults to OpenAI) or a Claude judge
+    )
 
-def get_default_metrics() -> Dict[str, BaseMetric]:
-    """Get default metrics. Creates instances lazily to avoid network calls during import."""
+
+def get_default_metrics(model: Optional[DeepEvalBaseLLM] = None) -> Dict[str, BaseMetric]:
+    """Get default metrics with the specified model. Creates instances lazily to avoid network calls during import."""
     return {
-        "CorrectnessMetric": GEval(
-            name="Correctness",
-            criteria="Determine whether the actual output is factually correct based on the expected output.",
-            # NOTE: you can only provide either criteria or evaluation_steps, and not both
-            evaluation_steps=[
-                "Check whether the facts in 'actual output' contradicts any facts in 'expected output'",
-                "You should also heavily penalize omission of detail",
-                "Vague language, or contradicting OPINIONS, are OK",
-            ],
-            threshold=0.8,
-            evaluation_params=[
-                LLMTestCaseParams.INPUT,
-                LLMTestCaseParams.ACTUAL_OUTPUT,
-                LLMTestCaseParams.EXPECTED_OUTPUT,
-            ],
-        ),
-        "DummyMetric": DummyMetric(threshold=0.5),
+        "CorrectnessMetric": make_geval(model = model), # Note: GEval defaults to OpenAI if no model is specified.
+        "DummyMetric": DummyMetric(threshold = 0.5)
     }
 
 
@@ -123,6 +131,8 @@ class EvalRunner:
 
     def __init__(self, verbose: bool = False):
         self.verbose = verbose
+        self.use_openai = True # GEval will default to OpenAI, avoid it and downgrade to another provider or metric if quota runs out.
+
         if verbose:
             logging.basicConfig(level=logging.DEBUG)
         else:
@@ -183,6 +193,40 @@ class EvalRunner:
             additional_metadata=case.additional_metadata,
         )
 
+    @functools.lru_cache(maxsize=1)
+    def _openai_quota_ok(self, model: str = "gpt-4o-mini") -> bool:
+        if not os.getenv("OPENAI_API_KEY"):
+            logger.warning("OPENAI_API_KEY is not set.")
+            return False
+        """
+            Preflight: detect “no OpenAI quota” and skip/redirect before calling evaluate.
+            Fast probe of the /chat/completions endpoint (the one GEval uses).
+            Returns False on 429 (insufficient_quota) or any exception.
+        """
+        try:
+            from openai import OpenAI
+            # turn off SDK retries for the check so it returns fast
+            client = OpenAI(max_retries=0, timeout=8)  # NO retries, quick fail
+            # messages = cast(List[ChatCompletionMessageParam], [{"role": "user", "content": "ping"}])
+            raw = [{"role": "user", "content": "ping"}]
+            messages = cast(List[ChatCompletionMessageParam], raw)
+            client.chat.completions.create(
+                model = model,
+                messages = messages,
+                max_tokens = 1,
+                temperature = 0,
+            )
+            return True
+        except APIStatusError as e:
+            # 429 insufficient_quota, or other status codes
+            if e.status_code == 429:
+                return False
+            return False
+        except Exception as e:
+            # includes 401 (bad key), 429 (insufficient_quota), network issues, etc.
+            logger.warning(f"OpenAI preflight failed; treating as no-quota: {e}")
+            return False
+
     def run_single_eval(
         self,
         model_name: str,
@@ -236,7 +280,29 @@ class EvalRunner:
 
             # Evaluate
             logger.info(f"Evaluating with {metric_name}")
-            eval_results = evaluate([test_case], [metric])
+
+            if isinstance(metric, GEval):
+                # Assume GEval will hit OpenAI unless we replace it.
+                if self.use_openai and not self._openai_quota_ok():
+                    self.use_openai = False
+                    logger.warning("OpenAI quota exhausted; downgrading to Claude...")
+                    from metacoder.evals.judges import ClaudeJudge
+                    try:
+                        # Downgrade to Claude judge in order to keep a real metric (even if not directly comparable to OpenAI).
+                        metric = make_geval(model = ClaudeJudge("claude-3-5-sonnet-20240620"))
+                    except Exception as e:
+                        # Fallback: if you can't use Claude, downgrade gracefully.
+                        logger.warning("Claude unavailable (%s); downgrading to DummyMetric.", e)
+                        metric = DummyMetric(threshold = 0.5)
+
+            eval_results = evaluate(
+                [test_case],
+                [metric],
+                async_config = AsyncConfig(run_async=False), # disable async
+                display_config = DisplayConfig(show_indicator=False, print_results=False, verbose_mode=self.verbose), # hide the spinner
+                cache_config = CacheConfig(use_cache=False, write_cache=False),
+                error_config = ErrorConfig(ignore_errors=False, skip_on_missing_params=True) # actually fail on failure
+            )
 
             # Extract results - the structure varies by deepeval version
             test_result = eval_results.test_results[0]

--- a/src/metacoder/evals/runner.py
+++ b/src/metacoder/evals/runner.py
@@ -524,7 +524,7 @@ class EvalRunner:
             results_data.append(result.model_dump())
 
         # Save as YAML
-        with open(output_path, "w") as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             yaml.dump(
                 {"results": results_data, "summary": self.generate_summary(results)},
                 f,

--- a/src/metacoder/metacoder.py
+++ b/src/metacoder/metacoder.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from pathlib import Path
 from typing import Optional, Union
 
@@ -542,6 +543,17 @@ def eval_command(config: str, output: str, workdir: str, coders: tuple, verbose:
     config_path = Path(config)
     output_path = Path(output)
     workdir_path = Path(workdir)
+
+    try:
+        # Create the output file only if it doesn't exist; fail if it does
+        with output_path.open("x", encoding="utf-8") as _:
+            pass
+    except FileExistsError:
+        print(
+            f"Error: '{output_path}' already exists. Please delete it or specify a different filename.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     # Convert coders tuple to list (empty tuple if not specified)
     coders_list = list(coders) if coders else None

--- a/src/metacoder/metacoder.py
+++ b/src/metacoder/metacoder.py
@@ -421,7 +421,9 @@ def run(
                 coder_config.ai_model.name = model
 
         # Show the model configuration
-        click.echo(f"🧠 AI Model: {coder_config.ai_model.name} (provider: {coder_config.ai_model.provider})")
+        click.echo(
+            f"🧠 AI Model: {coder_config.ai_model.name} (provider: {coder_config.ai_model.provider})"
+        )
 
     if coder_config and coder_config.extensions:
         for mcp in coder_config.extensions:
@@ -479,12 +481,16 @@ def run(
         click.echo("\n📋 Tool uses:")
         for tool_use in result.tool_uses:
             success = "✅" if tool_use.success else "❌"
-            click.echo(f"  {success} {tool_use.name} with arguments: {tool_use.arguments}")
+            click.echo(
+                f"  {success} {tool_use.name} with arguments: {tool_use.arguments}"
+            )
             if tool_use.error:
                 click.echo(f"    Error: {tool_use.error}")
 
     if verbose and result.structured_messages:
-        click.echo(f"\n📋 Structured messages ({len(result.structured_messages)} total)")
+        click.echo(
+            f"\n📋 Structured messages ({len(result.structured_messages)} total)"
+        )
         for i, msg in enumerate(result.structured_messages):
             click.echo(f"  {i + 1}. {msg}")
 
@@ -586,8 +592,16 @@ def eval_command(config: str, output: str, workdir: str, coders: tuple, verbose:
 
     # Print summary
     summary = runner.generate_summary(results)
-    frac_passed = summary['passed'] / summary['total_evaluations'] if summary['total_evaluations'] else 0
-    frac_failed = summary['failed'] / summary['total_evaluations'] if summary['total_evaluations'] else 0
+    frac_passed = (
+        summary["passed"] / summary["total_evaluations"]
+        if summary["total_evaluations"]
+        else 0
+    )
+    frac_failed = (
+        summary["failed"] / summary["total_evaluations"]
+        if summary["total_evaluations"]
+        else 0
+    )
 
     click.echo("\n📈 Summary:")
     click.echo(f"   Total: {summary['total_evaluations']}")
@@ -599,15 +613,23 @@ def eval_command(config: str, output: str, workdir: str, coders: tuple, verbose:
     if len(summary["by_coder"]) > 1:
         click.echo("\n   By Coder:")
         for coder, stats in summary["by_coder"].items():
-            coder_frac_passed = stats['passed'] / stats['total'] if stats['total'] else 0
-            click.echo(f"     {coder}: {stats['passed']} / {stats['total']} ({coder_frac_passed:.1%})")
+            coder_frac_passed = (
+                stats["passed"] / stats["total"] if stats["total"] else 0
+            )
+            click.echo(
+                f"     {coder}: {stats['passed']} / {stats['total']} ({coder_frac_passed:.1%})"
+            )
 
     # Print by-model summary
     if len(summary["by_model"]) > 1:
         click.echo("\n   By Model:")
         for model, stats in summary["by_model"].items():
-            model_frac_passed = stats['passed'] / stats['total'] if stats['total'] else 0
-            click.echo(f"     {model}: {stats['passed']} / {stats['total']} ({model_frac_passed:.1%})")
+            model_frac_passed = (
+                stats["passed"] / stats["total"] if stats["total"] else 0
+            )
+            click.echo(
+                f"     {model}: {stats['passed']} / {stats['total']} ({model_frac_passed:.1%})"
+            )
 
     click.echo("\n✅ Evaluation complete!")
 

--- a/src/metacoder/metacoder.py
+++ b/src/metacoder/metacoder.py
@@ -421,9 +421,7 @@ def run(
                 coder_config.ai_model.name = model
 
         # Show the model configuration
-        click.echo(
-            f"🧠 AI Model: {coder_config.ai_model.name} (provider: {coder_config.ai_model.provider})"
-        )
+        click.echo(f"🧠 AI Model: {coder_config.ai_model.name} (provider: {coder_config.ai_model.provider})")
 
     if coder_config and coder_config.extensions:
         for mcp in coder_config.extensions:
@@ -481,16 +479,12 @@ def run(
         click.echo("\n📋 Tool uses:")
         for tool_use in result.tool_uses:
             success = "✅" if tool_use.success else "❌"
-            click.echo(
-                f"  {success} {tool_use.name} with arguments: {tool_use.arguments}"
-            )
+            click.echo(f"  {success} {tool_use.name} with arguments: {tool_use.arguments}")
             if tool_use.error:
                 click.echo(f"    Error: {tool_use.error}")
 
     if verbose and result.structured_messages:
-        click.echo(
-            f"\n📋 Structured messages ({len(result.structured_messages)} total)"
-        )
+        click.echo(f"\n📋 Structured messages ({len(result.structured_messages)} total)")
         for i, msg in enumerate(result.structured_messages):
             click.echo(f"  {i + 1}. {msg}")
 
@@ -592,38 +586,28 @@ def eval_command(config: str, output: str, workdir: str, coders: tuple, verbose:
 
     # Print summary
     summary = runner.generate_summary(results)
+    frac_passed = summary['passed'] / summary['total_evaluations'] if summary['total_evaluations'] else 0
+    frac_failed = summary['failed'] / summary['total_evaluations'] if summary['total_evaluations'] else 0
+
     click.echo("\n📈 Summary:")
     click.echo(f"   Total: {summary['total_evaluations']}")
-    click.echo(
-        f"   Passed: {summary['passed']} ({summary['passed'] / summary['total_evaluations'] * 100:.1f}%)"
-    )
-    click.echo(
-        f"   Failed: {summary['failed']} ({summary['failed'] / summary['total_evaluations'] * 100:.1f}%)"
-    )
-    if summary["errors"] > 0:
-        click.echo(f"   Errors: {summary['errors']} ⚠️")
+    click.echo(f"   Passed: {summary['passed']} ({frac_passed:.1%})")
+    click.echo(f"   Failed: {summary['failed']} ({frac_failed:.1%})")
+    click.echo(f"   Errors: {summary['errors']} ⚠️") if summary["errors"] else None
 
     # Print by-coder summary
     if len(summary["by_coder"]) > 1:
         click.echo("\n   By Coder:")
         for coder, stats in summary["by_coder"].items():
-            pass_rate = (
-                stats["passed"] / stats["total"] * 100 if stats["total"] > 0 else 0
-            )
-            click.echo(
-                f"     {coder}: {stats['passed']}/{stats['total']} ({pass_rate:.1f}%)"
-            )
+            coder_frac_passed = stats['passed'] / stats['total'] if stats['total'] else 0
+            click.echo(f"     {coder}: {stats['passed']} / {stats['total']} ({coder_frac_passed:.1%})")
 
     # Print by-model summary
     if len(summary["by_model"]) > 1:
         click.echo("\n   By Model:")
         for model, stats in summary["by_model"].items():
-            pass_rate = (
-                stats["passed"] / stats["total"] * 100 if stats["total"] > 0 else 0
-            )
-            click.echo(
-                f"     {model}: {stats['passed']}/{stats['total']} ({pass_rate:.1f}%)"
-            )
+            model_frac_passed = stats['passed'] / stats['total'] if stats['total'] else 0
+            click.echo(f"     {model}: {stats['passed']} / {stats['total']} ({model_frac_passed:.1%})")
 
     click.echo("\n✅ Evaluation complete!")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import logging
+import sys
+
+
+def pytest_configure(config):
+    logging.basicConfig(
+        level=logging.WARNING,
+        format="\n%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        stream=sys.stdout,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import sys
 
 def pytest_configure(config):
     logging.basicConfig(
-        level=logging.WARNING,
+        level=logging.DEBUG,
         format="\n%(asctime)s [%(levelname)s] %(name)s: %(message)s",
         stream=sys.stdout,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import sys
 
 def pytest_configure(config):
     logging.basicConfig(
-        level=logging.DEBUG,
+        level=logging.WARNING,
         format="\n%(asctime)s [%(levelname)s] %(name)s: %(message)s",
         stream=sys.stdout,
     )

--- a/tests/input/goose_eval_claude_downgrade_test.yaml
+++ b/tests/input/goose_eval_claude_downgrade_test.yaml
@@ -1,0 +1,30 @@
+name: pubmed tools evals
+description: |
+  Evaluations for multiple pubmed MCPs
+
+coders:
+  goose: {}
+
+models:
+  claude-sonnet:
+    provider: anthropic
+    name: claude-sonnet-4-20250514
+
+servers:
+  mcp-simple-pubmed:
+    name: pubmed
+    command: uvx
+    args: [mcp-simple-pubmed]
+    env:
+      PUBMED_EMAIL: ctparker@lbl.gov
+
+server_combinations:
+  - [mcp-simple-pubmed]
+
+cases:
+- name: PMID_28027860_Full_Text
+  metrics: [CorrectnessMetric]
+  input: "What is the first sentence of section 2 in PMID: 28027860?"
+  expected_output: |
+    Even though many of NFLE's core features have been clarified in the last two decades, some critical issues remain controversial."
+  threshold: 0.9

--- a/tests/input/goose_eval_test.yaml
+++ b/tests/input/goose_eval_test.yaml
@@ -7,7 +7,7 @@ coders:
   goose: {}
 
 models:
-  gpt-4o:
+  claude-sonnet:
     provider: anthropic
     name: claude-sonnet-4-20250514
 
@@ -34,6 +34,9 @@ cases:
       MONDO:0011694 (spinocerebellar ataxia type 15/16, aka SCA15)
       MONDO:0007298 (spinocerebellar ataxia type 29, aka SCA29)
       MONDO:0008795 (aniridia-cerebellar ataxia-intellectual disability syndrome; aka Gillespie syndrome)
-
     threshold: 0.7
-    
+  - name: character_encoding_test
+    metrics: [CorrectnessMetric]
+    input: Based on PMID 33926573 do microbes from alkaline sulphidic tailings show oxidative stresses?
+    expected_output: 'The paper says No but it is retracted so the results should not be trusted.'
+    threshold: 0.9

--- a/tests/input/goose_no_server_test.yaml
+++ b/tests/input/goose_no_server_test.yaml
@@ -1,0 +1,30 @@
+name: pubmed tools evals
+description: |
+  Evaluations for multiple pubmed MCPs
+
+coders:
+  goose: {}
+
+models:
+  claude-sonnet:
+    provider: anthropic
+    name: claude-sonnet-4-20250514
+
+servers:
+  mcp-simple-pubmed:
+    name: pubmed
+    command: uvx
+    args: [mcp-simple-pubmed]
+    env:
+      PUBMED_EMAIL: ctparker@lbl.gov
+
+#server_combinations:
+#  - [mcp-simple-pubmed]
+
+cases:
+- name: PMID_28027860_Full_Text
+  metrics: [CorrectnessMetric]
+  input: "What is the first sentence of section 2 in PMID: 28027860?"
+  expected_output: |
+    Even though many of NFLE's core features have been clarified in the last two decades, some critical issues remain controversial."
+  threshold: 0.9

--- a/tests/input/literature_mcp_encoding_test.yaml
+++ b/tests/input/literature_mcp_encoding_test.yaml
@@ -1,0 +1,29 @@
+name: pubmed tools evals
+description: |
+  Evaluations for multiple pubmed MCPs
+
+
+coders:
+  goose: {}
+
+models:
+  claude-sonnet:
+    provider: anthropic
+    name: claude-sonnet-4-20250514
+
+servers:
+  ols:
+    name: ols
+    command: uvx
+    args: [mcp-ols]
+
+server_combinations:
+  - [simple-pubmed]
+
+cases:
+- name: character_encoding_test
+  metrics:
+  - CorrectnessMetric
+  input: Based on PMID 33926573 do microbes from alkaline sulphidic tailings show oxidative stresses?
+  expected_output: 'The paper says No but it is retracted so the results should not be trusted.'
+  threshold: 0.9

--- a/tests/input/literature_mcp_encoding_test.yaml
+++ b/tests/input/literature_mcp_encoding_test.yaml
@@ -27,3 +27,11 @@ cases:
   input: Based on PMID 33926573 do microbes from alkaline sulphidic tailings show oxidative stresses?
   expected_output: 'The paper says No but it is retracted so the results should not be trusted.'
   threshold: 0.9
+- name: "disease"
+  metrics: [CorrectnessMetric]
+  input: "According to PMID:35743164, What 3 diseases are associated with ITPR1 mutations? Give me disease names and MONDO IDs"
+  expected_output: |
+    MONDO:0011694 (spinocerebellar ataxia type 15/16, aka SCA15)
+    MONDO:0007298 (spinocerebellar ataxia type 29, aka SCA29)
+    MONDO:0008795 (aniridia-cerebellar ataxia-intellectual disability syndrome; aka Gillespie syndrome)
+  threshold: 0.7

--- a/tests/input/literature_mcp_encoding_test.yaml
+++ b/tests/input/literature_mcp_encoding_test.yaml
@@ -27,11 +27,3 @@ cases:
   input: Based on PMID 33926573 do microbes from alkaline sulphidic tailings show oxidative stresses?
   expected_output: 'The paper says No but it is retracted so the results should not be trusted.'
   threshold: 0.9
-- name: "disease"
-  metrics: [CorrectnessMetric]
-  input: "According to PMID:35743164, What 3 diseases are associated with ITPR1 mutations? Give me disease names and MONDO IDs"
-  expected_output: |
-    MONDO:0011694 (spinocerebellar ataxia type 15/16, aka SCA15)
-    MONDO:0007298 (spinocerebellar ataxia type 29, aka SCA29)
-    MONDO:0008795 (aniridia-cerebellar ataxia-intellectual disability syndrome; aka Gillespie syndrome)
-  threshold: 0.7

--- a/tests/test_coders/test_coders_basic.py
+++ b/tests/test_coders/test_coders_basic.py
@@ -3,6 +3,7 @@
 These tests check that each coder can handle a simple arithmetic question.
 """
 
+import json
 import tempfile
 import pytest
 
@@ -164,3 +165,16 @@ def test_dummy_coder_always_works():
         assert result is not None
         assert result.result_text == "you said: Hello, world!"
         assert result.stdout == "you said: Hello, world!"
+
+
+@pytest.mark.integration
+def test_goose_utf8_session_file(tmp_path):
+    """Test session files with UTF-8 content are read correctly."""
+    session_content = '{"role": "assistant", "content": "测试 résumé 🚀"}\n'
+    session_file = tmp_path / "test_session.jsonl"
+    session_file.write_text(session_content, encoding="utf-8")
+
+    with open(session_file, "r", encoding="utf-8") as f:
+        messages = [json.loads(line) for line in f if line.strip()]
+    assert len(messages) == 1
+    assert "测试" in messages[0]["content"]

--- a/tests/test_evals/test_claude_judge.py
+++ b/tests/test_evals/test_claude_judge.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import traceback
 from pathlib import Path
 
 from metacoder.evals.runner import EvalRunner
@@ -9,9 +11,9 @@ logger = logging.getLogger(__name__)
 def test_claude_judge_downgrade_success(tmp_path, caplog, monkeypatch):
     """Test that ClaudeJudge is used when OpenAI is disabled."""
 
-    # Temporarily set an invalid OPENAI_API_KEY in order to force OpenAI calls to fail.
-    # (no need to reset, `monkeypatch` automatically reverts after the test)
-    monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key-for-testing")
+    # # Temporarily set an invalid OPENAI_API_KEY in order to force OpenAI calls to fail.
+    # # (no need to reset, `monkeypatch` automatically reverts after the test)
+    # monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key-for-testing")
 
     runner = EvalRunner()
 
@@ -24,11 +26,25 @@ def test_claude_judge_downgrade_success(tmp_path, caplog, monkeypatch):
         # One enhancement might be to introduce metric_model=claude-3-5-sonnet-20240620 to each result at eval time.
         # Instead, resort to capturing the WARNING logs for assertions related to the downgrade.
         with caplog.at_level(logging.WARNING):
-            results = runner.run_all_evals(dataset, workdir=tmp_path, coders=["goose"])
+            # Temporarily set an invalid OPENAI_API_KEY in order to force OpenAI calls to fail.
+            # (no need to reset, `monkeypatch` automatically reverts after the test)
+            # Save the original OPENAI_API_KEY if it exists
+            # original_api_key = os.getenv("OPENAI_API_KEY")
+            monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key-for-testing")
+
+            results = runner.run_all_evals(
+                dataset, workdir=tmp_path, coders=["goose", "dummy"]
+            )
+
+            # # Revert the OPENAI_API_KEY to its original value
+            # if original_api_key is not None:
+            #     monkeypatch.setenv("OPENAI_API_KEY", original_api_key)
+            # else:
+            #     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
             # Verfiy that the downgrade happened.
             assert (
-                "OpenAI API quota exhausted or server unavailable; downgrading to claude-3-5-sonnet-20240620"
+                "OpenAI API quota exhausted or server unavailable; disabling OpenAI for DeepEval."
                 in caplog.text
             )
 
@@ -37,5 +53,10 @@ def test_claude_judge_downgrade_success(tmp_path, caplog, monkeypatch):
                 f"Expected ClaudeJudge to score {results[0].metric_name} for {results[0].case_name}"
             )
 
+    except Exception as e:
+        logger.error(f"An error occurred: {e}")
+        # traceback.print_exc()
+        logging.error(traceback.format_exc())
+        assert False  # force test to fail if an exception is caught here
     finally:
         pass

--- a/tests/test_evals/test_claude_judge.py
+++ b/tests/test_evals/test_claude_judge.py
@@ -14,13 +14,18 @@ def test_claude_judge_downgrade_success(tmp_path, caplog, monkeypatch):
     runner = EvalRunner()
 
     try:
-        dataset = runner.load_dataset(Path("tests/input/goose_eval_claude_downgrade_test.yaml"))
+        dataset = runner.load_dataset(
+            Path("tests/input/goose_eval_claude_downgrade_test.yaml")
+        )
 
         # Unfortunately, there is nothing available in the eval results that indicate which model DeepEval used.
         # Instead, resort to capturing the WARNING logs for assertions related to the downgrade.
         with caplog.at_level(logging.WARNING):
             results = runner.run_all_evals(dataset, workdir=tmp_path, coders=["goose"])
-            assert "OpenAI API quota exhausted or server unavailable; downgrading to claude-3-5-sonnet-20240620" in caplog.text
+            assert (
+                "OpenAI API quota exhausted or server unavailable; downgrading to claude-3-5-sonnet-20240620"
+                in caplog.text
+            )
 
     finally:
         pass

--- a/tests/test_evals/test_claude_judge.py
+++ b/tests/test_evals/test_claude_judge.py
@@ -9,6 +9,8 @@ logger = logging.getLogger(__name__)
 
 def test_claude_judge_downgrade_success(tmp_path, caplog, monkeypatch):
     """Test that ClaudeJudge is used when OpenAI is disabled."""
+    # TODO: This test should avoid running the coder and only perform the eval step.
+    # Otherwise, it is impossible to get to the eval step if no valid API key is present or no quota is available (testing the wrong part of the process).
 
     runner = EvalRunner()
 
@@ -40,6 +42,88 @@ def test_claude_judge_downgrade_success(tmp_path, caplog, monkeypatch):
                 "Downgrading CorrectnessMetric model from gpt-4.1 to claude-3-5-sonnet-20240620."
                 in caplog.text
             )
+
+            # Test that the eval completed by checking for a non-zero score.
+            assert results[0].score > 0, (
+                f"Expected a {results[0].metric_name} score for {results[0].case_name}."
+            )
+
+    except Exception as e:
+        # Test that fallback logic does not result in an Exception.
+        logger.error(f"An error occurred: {e}")
+        logging.error(traceback.format_exc())
+        assert False  # This assertion will fail if an Exception is caught here.
+    finally:
+        pass
+
+
+def test_correctnessmetric_downgrade_success(tmp_path, caplog, monkeypatch):
+    """Test that the CorrectnessMatric is successfully downgraded to DummyMetric if no model is available."""
+
+    runner = EvalRunner()
+
+    try:
+        dataset = runner.load_dataset(
+            Path("tests/input/goose_eval_claude_downgrade_test.yaml")
+        )
+
+        # Unfortunately, there is nothing available in the eval results that indicate which model DeepEval used.
+        # One enhancement might be to introduce metric_model=claude-3-5-sonnet-20240620 to each result at eval time.
+        # Instead, resort to capturing the WARNING logs for assertions related to the downgrade.
+        with caplog.at_level(logging.WARNING):
+            # Temporarily set an invalid OPENAI_API_KEY in order to force OpenAI calls to fail.
+            # (no need to reset, `monkeypatch` automatically reverts after the test)
+            monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key-for-testing")
+
+            # Delete the Anthropic API Key from the environment to force ClaudeJudge instantiation to fail.
+            # (no need to reset, `monkeypatch` automatically reverts after the test)
+            monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+            # One more OpenAI API test case also needs to be handled (401 errors):
+            # Temporarily set an invalid ANTHROPIC_API_KEY in order to force ClaudeJudge to fail.
+            # monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+            # One more Anthropic API test case also needs to be handled (401 errors):
+            # Temporarily set an invalid ANTHROPIC_API_KEY in order to force ClaudeJudge to fail.
+            # monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-api-key-for-testing")
+
+            # TODO: Also need to test this for Anthropic:
+            # Provider
+            # request
+            # failed
+            # with status: 400
+            # Bad
+            # Request.Payload: Some(Object
+            # {"error": Object {"message": String("Your credit balance is too low
+            #                   to access the Anthropic API.Please go to Plans & Billing to upgrade or purchase
+            #                   credits."), "type": String("invalid_request_error")}, "request_id": String("
+            #                   req_011CSeQZTjJvmcxzrhXuPES4"), "type": Strin
+            #                   g("error")}).Returning
+            # error: RequestFailed(
+            #     "Request failed with status: 400 Bad Request. Message: Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."
+
+            results = runner.run_all_evals(dataset, workdir=tmp_path, coders=["dummy"])
+
+            # Test that the quota exhaustion fallback logic worked as expected.
+            assert (
+                "OpenAI API quota exhausted or server unavailable; disabling OpenAI for DeepEval."
+                in caplog.text
+            )
+
+            # Test that the new evaluation judge was correctly selected for the metric model downgrade.
+            assert (
+                "Downgrading CorrectnessMetric model from gpt-4.1 to claude-3-5-sonnet-20240620."
+                in caplog.text
+            )
+
+            # Test that the ClaudeJudge was unable to be used as the model for the CorrectnessMetric.
+            assert (
+                "Claude unavailable (ANTHROPIC_API_KEY is not set in environment); downgrading CorrectnessMetric to DummyMetric."
+                in caplog.text
+            )
+
+            # Test that the CorrectnessMetric was successfully downgraded to DummyMetric.
+            assert "Downgraded CorrectnessMetric to DummyMetric." in caplog.text
 
             # Test that the eval completed by checking for a non-zero score.
             assert results[0].score > 0, (

--- a/tests/test_evals/test_claude_judge.py
+++ b/tests/test_evals/test_claude_judge.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from metacoder.evals.runner import EvalRunner
 
+logger = logging.getLogger(__name__)
+
 
 def test_claude_judge_downgrade_success(tmp_path, caplog, monkeypatch):
     """Test that ClaudeJudge is used when OpenAI is disabled."""
@@ -19,12 +21,20 @@ def test_claude_judge_downgrade_success(tmp_path, caplog, monkeypatch):
         )
 
         # Unfortunately, there is nothing available in the eval results that indicate which model DeepEval used.
+        # One enhancement might be to introduce metric_model=claude-3-5-sonnet-20240620 to each result at eval time.
         # Instead, resort to capturing the WARNING logs for assertions related to the downgrade.
         with caplog.at_level(logging.WARNING):
             results = runner.run_all_evals(dataset, workdir=tmp_path, coders=["goose"])
+
+            # Verfiy that the downgrade happened.
             assert (
                 "OpenAI API quota exhausted or server unavailable; downgrading to claude-3-5-sonnet-20240620"
                 in caplog.text
+            )
+
+            # Verify that the eval completed by checking for a non-zero score.
+            assert results[0].score > 0, (
+                f"Expected ClaudeJudge to score {results[0].metric_name} for {results[0].case_name}"
             )
 
     finally:

--- a/tests/test_evals/test_claude_judge.py
+++ b/tests/test_evals/test_claude_judge.py
@@ -29,20 +29,27 @@ def test_claude_judge_downgrade_success(tmp_path, caplog, monkeypatch):
                 dataset, workdir=tmp_path, coders=["goose", "dummy"]
             )
 
-            # Verfiy that the downgrade happened.
+            # Test that the quota exhaustion fallback logic worked as expected.
             assert (
                 "OpenAI API quota exhausted or server unavailable; disabling OpenAI for DeepEval."
                 in caplog.text
             )
 
-            # Verify that the eval completed by checking for a non-zero score.
+            # Test that the new evaluation judge was correctly selected for the metric model downgrade.
+            assert (
+                "Downgrading CorrectnessMetric model from gpt-4.1 to claude-3-5-sonnet-20240620."
+                in caplog.text
+            )
+
+            # Test that the eval completed by checking for a non-zero score.
             assert results[0].score > 0, (
-                f"Expected ClaudeJudge to score {results[0].metric_name} for {results[0].case_name}"
+                f"Expected a {results[0].metric_name} score for {results[0].case_name}."
             )
 
     except Exception as e:
+        # Test that fallback logic does not result in an Exception.
         logger.error(f"An error occurred: {e}")
         logging.error(traceback.format_exc())
-        assert False  # force test to fail if an exception is caught here
+        assert False  # This assertion will fail if an Exception is caught here.
     finally:
         pass

--- a/tests/test_evals/test_claude_judge.py
+++ b/tests/test_evals/test_claude_judge.py
@@ -1,0 +1,26 @@
+import logging
+from pathlib import Path
+
+from metacoder.evals.runner import EvalRunner
+
+
+def test_claude_judge_downgrade_success(tmp_path, caplog, monkeypatch):
+    """Test that ClaudeJudge is used when OpenAI is disabled."""
+
+    # Temporarily set an invalid OPENAI_API_KEY in order to force OpenAI calls to fail.
+    # (no need to reset, `monkeypatch` automatically reverts after the test)
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key-for-testing")
+
+    runner = EvalRunner()
+
+    try:
+        dataset = runner.load_dataset(Path("tests/input/goose_eval_claude_downgrade_test.yaml"))
+
+        # Unfortunately, there is nothing available in the eval results that indicate which model DeepEval used.
+        # Instead, resort to capturing the WARNING logs for assertions related to the downgrade.
+        with caplog.at_level(logging.WARNING):
+            results = runner.run_all_evals(dataset, workdir=tmp_path, coders=["goose"])
+            assert "OpenAI API quota exhausted or server unavailable; downgrading to claude-3-5-sonnet-20240620" in caplog.text
+
+    finally:
+        pass

--- a/tests/test_evals/test_claude_judge.py
+++ b/tests/test_evals/test_claude_judge.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import traceback
 from pathlib import Path
 
@@ -10,10 +9,6 @@ logger = logging.getLogger(__name__)
 
 def test_claude_judge_downgrade_success(tmp_path, caplog, monkeypatch):
     """Test that ClaudeJudge is used when OpenAI is disabled."""
-
-    # # Temporarily set an invalid OPENAI_API_KEY in order to force OpenAI calls to fail.
-    # # (no need to reset, `monkeypatch` automatically reverts after the test)
-    # monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key-for-testing")
 
     runner = EvalRunner()
 
@@ -28,19 +23,11 @@ def test_claude_judge_downgrade_success(tmp_path, caplog, monkeypatch):
         with caplog.at_level(logging.WARNING):
             # Temporarily set an invalid OPENAI_API_KEY in order to force OpenAI calls to fail.
             # (no need to reset, `monkeypatch` automatically reverts after the test)
-            # Save the original OPENAI_API_KEY if it exists
-            # original_api_key = os.getenv("OPENAI_API_KEY")
             monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key-for-testing")
 
             results = runner.run_all_evals(
                 dataset, workdir=tmp_path, coders=["goose", "dummy"]
             )
-
-            # # Revert the OPENAI_API_KEY to its original value
-            # if original_api_key is not None:
-            #     monkeypatch.setenv("OPENAI_API_KEY", original_api_key)
-            # else:
-            #     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
             # Verfiy that the downgrade happened.
             assert (
@@ -55,7 +42,6 @@ def test_claude_judge_downgrade_success(tmp_path, caplog, monkeypatch):
 
     except Exception as e:
         logger.error(f"An error occurred: {e}")
-        # traceback.print_exc()
         logging.error(traceback.format_exc())
         assert False  # force test to fail if an exception is caught here
     finally:


### PR DESCRIPTION
**Commit 1:**

- Fixes #14
- Goose coder now always opens Goose session files as UTF-8.

**Commit 2:**

- Fixes #15
- Summaries use consistent logic and printing methods to avoid divide by zero errors.

**Commit 3:**

- Fixes inconsistent printing of command runtimes among the coders.

**Commit 4:**

- Fixes #18
- Disables asynchronous OpenAPI calls in eval (related: also disables progress meters and spinners).
- Downgrades to Claude model if OpenAPI calls fail.
- Downgrades to DummyMetric if Claude fails.

**Commit 5:**

- Addressed violations of ruff rules.

**Commit 6:**

- Added test case.
- Added extra logging.

**Commit 7:**

- Added metacoder config test case cited below in Test Results.

**Commit 8:**

- Added unit test for claude downgrade to support Issue #18.
- Cleaned up logging in runner.py.
- Added test configuration to support log capture for assertions that downgrade was successful.

**Commit 9:**

- Addressed ruff warnings.

**Commit 10:**

- Added assertion to confirm that ClaudeJudge successfully scores the Correctness metric after a downgrade.

**Commit 11:**

- Added assertion to force test to fail on Exception.
- Increased logging verbosity temporarily to debug Claude judge unit test on build server.
- Adjusted logic to work when multiple coders are specified.
- Improved log messages for clarity.

**Commit 12:**

- Fixed runtime issues related to metric downgrade from `CorrectnessMetric` to `DummyMetric`.
- Changed `RuntimeError` to `Exception` when Anthropic API key is missing.

**Commit 13:**

- Added test coverage of new evaluation judge functionality.
- Added test for the quota exhaustion fallback logic.

**Commit 14:**

- Reduced logging verbosity.
- Added Anthropic quota check.
- Added automatic downgrade to DummyMetric on quota check failure.
- Added notes on potential improvements to unit tests.

**Commit 15:**

- Fixes #23. Forced processes to be launched with UTF-8 encoding to avoid default encoding errors.

**Commit 16:**

- Addressed ruff formatting issue.

**Commit 17:**

- Related to #24. Added check and fail when output file already exists.

**[Commit 18:](https://github.com/ai4curation/metacoder/pull/16/commits/c436e7fe4698df2c8e3d3e04fa5af8224ade0f9a)** (reverted by Commit 20)

- ~~Fixes #24. Modified save_results to append to existing output file rather than overwrite.~~
- ~~Enforced UTF-8 encoding.~~
- ~~Switched to `safe_dump` and added document delimiter between records.~~
- ~~Simplified document generation.~~
- ~~Added second case to `literature_mcp_encoding_test.yaml` for testing.~~

**Commit 19:**

- Updated ClaudeJudge to claude-4 model.

**Commit 20:**

- Reverted Commit 18 (see above) at request of @cmungall 
- **Note:** UTF-8 character encoding may need to be re-introduced to `open()` for Windows support.

**Commit 21:**

- Added UTF-8 encoding to prevent character mangling during YAML export on Windows (where the default codepage is cp1252).

---

**Test Results (successfully downgrades from OpenAI to Claude, in contrast to same example from Issue #18 )**

```
(metacoder) PS C:\Users\CTParker\PycharmProjects\metacoder> pytest -v tests\test_evals\test_claude_judge.py
========================================================================================== test session starts ===========================================================================================
platform win32 -- Python 3.10.16, pytest-8.4.1, pluggy-1.6.0 -- C:\Users\CTParker\PycharmProjects\metacoder\.venv\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\CTParker\PycharmProjects\metacoder
configfile: pytest.ini
plugins: anyio-4.9.0, deepeval-3.3.4, langsmith-0.4.10, asyncio-1.1.0, repeat-0.9.4, rerunfailures-12.0, xdist-3.8.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item                                                                                                                                                                                          

tests/test_evals/test_claude_judge.py::test_claude_judge_downgrade_success 
2025-08-30 14:18:51,405 [WARNING] metacoder.evals.runner: OpenAI API Authentication Error: Error code: 401 - {'error': {'message': 'Incorrect API key provided: fake-api************ting. You can find your API key at https://platform.openai.com/account/api-keys.', 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_api_key'}}

2025-08-30 14:18:51,405 [WARNING] metacoder.evals.runner: OpenAI API quota exhausted or server unavailable; disabling OpenAI for DeepEval.

2025-08-30 14:18:51,410 [WARNING] metacoder.evals.runner: Downgrading CorrectnessMetric model from gpt-4.1 to claude-3-5-sonnet-20240620.

2025-08-30 14:18:51,433 [WARNING] metacoder.evals.runner: Successfully downgraded CorrectnessMetric model to claude-3-5-sonnet-20240620.

2025-08-30 14:18:51,434 [WARNING] metacoder.evals.runner: Actual metric used: Correctness.

2025-08-30 14:18:53,651 [WARNING] metacoder.evals.runner: Downgrading CorrectnessMetric model from gpt-4.1 to claude-3-5-sonnet-20240620.

2025-08-30 14:18:53,664 [WARNING] metacoder.evals.runner: Successfully downgraded CorrectnessMetric model to claude-3-5-sonnet-20240620.

2025-08-30 14:18:53,665 [WARNING] metacoder.evals.runner: Actual metric used: Correctness.
PASSED                                                                                                                   [100%]Running teardown with pytest sessionfinish...


=========================================================================================== 1 passed in 23.25s =========================================================================================== 

2025-08-30 14:18:55,710 [DEBUG] httpcore.connection: close.started

2025-08-30 14:18:55,710 [DEBUG] httpcore.connection: close.complete

2025-08-30 14:18:55,710 [DEBUG] httpcore.connection: close.started

2025-08-30 14:18:55,710 [DEBUG] httpcore.connection: close.complete

2025-08-30 14:18:55,710 [DEBUG] httpcore.connection: close.started

2025-08-30 14:18:55,710 [DEBUG] httpcore.connection: close.complete
```