### PR TITLE
Add disable_shell_tool option to CodexCoder for MCP-only evaluation

### DIFF
--- a/src/metacoder/coders/codex.py
+++ b/src/metacoder/coders/codex.py
@@ -42,8 +42,17 @@ class CodexCoder(BaseCoder):
         args = ["mcp-server-name"]
         env = { "API_KEY" = "value" }
 
+    Coder Options (passed via coders config in YAML):
+
+        coders:
+          codex:
+            disable_shell_tool: true  # Disable shell/bash access, MCP-only mode
+
     Note: Requires codex CLI to be installed.
     """
+
+    # Coder-specific options (set from YAML config)
+    disable_shell_tool: bool = False
 
     @classmethod
     def is_available(cls) -> bool:
@@ -142,7 +151,19 @@ class CodexCoder(BaseCoder):
             # Codex reads .codex/config.toml from current directory automatically.
             # Do NOT set HOME=. as this breaks authentication (401 Unauthorized).
             text = self.expand_prompt(input_text)
-            command = ["codex", "exec", "--json", "--dangerously-bypass-approvals-and-sandbox", text]
+
+            # Build command with appropriate flags
+            if self.disable_shell_tool:
+                # MCP-only mode: disable shell tool to prevent filesystem access
+                # This forces Codex to use only MCP tools for retrieving information
+                command = [
+                    "codex", "exec", "--json", "--full-auto",
+                    "--skip-git-repo-check", "--disable", "shell_tool", text
+                ]
+                logger.info("Running Codex in MCP-only mode (shell_tool disabled)")
+            else:
+                # Default mode: full access (for general use cases)
+                command = ["codex", "exec", "--json", "--dangerously-bypass-approvals-and-sandbox", text]
 
             print(f"📝 Running command: {' '.join(command)}")
             # time the command

--- a/src/metacoder/evals/runner.py
+++ b/src/metacoder/evals/runner.py
@@ -157,8 +157,20 @@ def get_default_metrics(
     }
 
 
-def create_coder(coder_name: str, workdir: str, config=None) -> BaseCoder:
-    """Create a coder instance."""
+def create_coder(
+    coder_name: str,
+    workdir: str,
+    config=None,
+    coder_options: Optional[Dict[str, Any]] = None,
+) -> BaseCoder:
+    """Create a coder instance.
+
+    Args:
+        coder_name: Name of the coder (e.g., 'codex', 'claude', 'goose')
+        workdir: Working directory for the coder
+        config: CoderConfig with model and extensions
+        coder_options: Coder-specific options from YAML config (e.g., disable_shell_tool)
+    """
     if coder_name not in AVAILABLE_CODERS:
         available = ", ".join(AVAILABLE_CODERS.keys())
         raise ValueError(f"Unknown coder: {coder_name}. Available: {available}")
@@ -171,6 +183,15 @@ def create_coder(coder_name: str, workdir: str, config=None) -> BaseCoder:
     # Apply config if provided
     if config:
         coder.config = config
+
+    # Apply coder-specific options (e.g., disable_shell_tool for Codex)
+    if coder_options:
+        for key, value in coder_options.items():
+            if hasattr(coder, key):
+                setattr(coder, key, value)
+                logger.info(f"Set coder option: {key}={value}")
+            else:
+                logger.warning(f"Unknown coder option for {coder_name}: {key}")
 
     return coder
 
@@ -311,6 +332,7 @@ class EvalRunner:
         case: EvalCase,
         workdir: Path,
         coder_config: CoderConfig | None = None,
+        coder_options: Optional[Dict[str, Any]] = None,
     ) -> List[EvalResult]:
         """Run evaluation for a single model x coder x case combination."""
         results = []
@@ -320,6 +342,7 @@ class EvalRunner:
             coder_name,
             workdir=str(workdir),
             config=coder_config,
+            coder_options=coder_options,
         )
 
         # Set environment variables for the model
@@ -589,6 +612,7 @@ class EvalRunner:
                             case,
                             combo_workdir,
                             coder_config,
+                            coder_options=coder_config_base,  # Pass coder-specific options
                         )
 
                         # Add server info to results


### PR DESCRIPTION
## Summary

Adds a configurable `disable_shell_tool` option to CodexCoder that prevents filesystem access via bash commands, enabling fair MCP-only evaluations.

**Note: This PR is based on the `fix-gemini-cli-invocation` branch** which contains all previous Codex CLI fixes (MCP support, proper invocation, 401 fix, etc.). This should be merged after that branch is merged, or both can be merged together.

## Changes

- Added `disable_shell_tool` attribute to CodexCoder class
- When enabled, Codex runs with `--disable shell_tool` flag instead of `--dangerously-bypass-approvals-and-sandbox`
- Updated `create_coder()` and `run_single_eval()` to pass coder-specific options from YAML config

## Usage

```yaml
coders:
  codex:
    disable_shell_tool: true  # MCP-only mode
```

## Motivation

During MCP literature evaluations, we discovered Codex was using shell commands (`rg`, `sed`, `find`) to access the filesystem and read expected answers from test case files. This made the evaluation results invalid.

With `disable_shell_tool: true`, Codex can only use MCP tools to retrieve information, ensuring a fair comparison with other agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)